### PR TITLE
Fix PHP deprecation errors

### DIFF
--- a/src/com/zoho/crm/api/exception/SDKException.php
+++ b/src/com/zoho/crm/api/exception/SDKException.php
@@ -30,7 +30,7 @@ class SDKException extends \Exception
         {
             $this->_message = $cause->getMessage();
         }
-        parent::__construct($message);
+        parent::__construct(is_null($message) ? "" : $message);
     }
 
     /**


### PR DESCRIPTION
Facing issue with deprecations and same thing fixed in previous versions. https://github.com/zoho/zohocrm-php-sdk/pull/31